### PR TITLE
fix for unable to parse character reference '''' error from IG Publisher

### DIFF
--- a/includes/fragment-pageend.html
+++ b/includes/fragment-pageend.html
@@ -70,6 +70,7 @@ anchors.add()</script>
 
 {% if site.data.features.feedback.active %}
 <script type="text/javascript">
+/* <![CDATA[ */
   $(':header[id]').each(function() {
     var id = $(this).attr('id');
     var feedbackurl = '{{site.data.features.feedback.formUrl}}';
@@ -96,6 +97,7 @@ anchors.add()</script>
       });
     }
   })
+/* ]]> */
 </script>  
 {% endif %}
 


### PR DESCRIPTION
The IG publisher returns an error messages because of the feedback template:

unable to parse character reference '''' (last text = ' ' at line 322 column 37
eg see: http://build.fhir.org/ig/hl7-be/riziv-inami/qa.html

this is due to that the IG Publisher checks for valid xhtml, and & is not valid xhtml. it is valid javascript, therefore
it has to be embedded with CDATA, for additional background info see also discussion here:

https://web.archive.org/web/20140304083226/http://javascript.about.com/library/blxhtml.htm